### PR TITLE
feat: Add format revealed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ const vgsShow = React.useRef<VgsShowAttribute> = null;
 <Button onPress={vgsShow.current?.reveal(PATH, METHOD, CUSTOM_PAYLOAD)}>
 ```
 
+## Format data
+
+
+```tsx
+import VgsShowAttribute from 'vgs-show-react-native';
+
+// ...
+
+const vgsShow = React.useRef<VgsShowAttribute> = null;
+
+<VgsShowAttribute
+  ref={vgsShow}
+  initParams={{
+    environment: ENV,
+    vaultId: VAULT_ID,
+    // optional, if needed for the upstream service
+    customHeaders: {
+      Authorization: 'Bearer ' + customerToken,
+    },
+  }}
+  format={{
+    pattern:"(\\d{4})(\\d{4})(\\d{4})(\\d{4})"
+    template:"$1 $2 $3 $4"
+  }}
+  contentPath="data.attributes.pan"
+  placeholder="Value will appear here"
+  style={styles.box}
+/>;
+
+// To trigger reveal:
+<Button onPress={vgsShow.current?.reveal(PATH, METHOD, CUSTOM_PAYLOAD)}>
+```
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.

--- a/android/src/main/java/com/vgsshowreactnative/VgsShowReactNativeViewManager.kt
+++ b/android/src/main/java/com/vgsshowreactnative/VgsShowReactNativeViewManager.kt
@@ -103,4 +103,19 @@ class VgsShowReactNativeViewManager : SimpleViewManager<View>() {
       }
     }
   }
+
+  @ReactProp(name = "format")
+  fun setFormat(view: View, format: ReadableMap) {
+    if (format.hasKey("pattern") && format.hasKey("template")) {
+      val pattern = format.getString("pattern");
+      val template = format.getString("template");
+
+      pattern?.let {
+        val pat = it;
+        template?.let {
+          (view as VgsAttrInstance).vgsText.addTransformationRegex(pat.toRegex(), it);
+        }
+      }
+    }
+  }
 }

--- a/ios/VgsShowReactNativeViewManager.m
+++ b/ios/VgsShowReactNativeViewManager.m
@@ -17,6 +17,8 @@ RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)
 // Functionality
 RCT_EXPORT_VIEW_PROPERTY(initParams, NSDictionary)
 
+RCT_EXPORT_VIEW_PROPERTY(format, NSDictionary)
+
 RCT_EXTERN_METHOD(revealData:(nonnull NSNumber *)node path:(nonnull NSString *)path method:(NSString *)method payload:(NSDictionary *)payload
           resolver:(RCTPromiseResolveBlock)resolve
           rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/VgsShowReactNativeViewManager.swift
+++ b/ios/VgsShowReactNativeViewManager.swift
@@ -3,11 +3,11 @@ import VGSShowSDK
 
 @objc(VgsShowReactNativeViewManager)
 class VgsShowReactNativeViewManager: RCTViewManager {
-
+    
     override func view() -> (VgsShowReactNativeView) {
         return VgsShowReactNativeView()
     }
-
+    
     @objc(revealData:path:method:payload:resolver:rejecter:) func revealData(_ node: NSNumber, path: String, method: String, payload: VGSJSONData, resolver resolve: @escaping RCTPromiseResolveBlock,
                                                                              rejecter reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
@@ -22,13 +22,13 @@ class VgsShowReactNativeViewManager: RCTViewManager {
 class VgsShowReactNativeView : UIView, VGSLabelDelegate {
     var vgsShow: VGSShow?;
     let attributeLabel = VGSLabel()
-
+    
     @objc var initParams: NSDictionary = NSDictionary() {
         didSet {
             let vaultId = initParams["vaultId"] as! String;
             let environment = initParams["environment"] as! String;
             let customHeaders = initParams.object(forKey: "customHeaders") != nil ? initParams["customHeaders"] as! Dictionary<String, String> : [:];
-
+            
             if (vaultId != nil && environment != nil) {
                 if (environment == "live") {
                     vgsShow = VGSShow(id: vaultId, environment: .live);
@@ -37,7 +37,7 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
                     vgsShow = VGSShow(id: vaultId, environment: .sandbox);
                     vgsShow!.subscribe(attributeLabel)
                 }
-
+                
                 if (vgsShow != nil) {
                     vgsShow?.customHeaders = customHeaders;
                 }
@@ -55,7 +55,7 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
             }
         }
     }
-
+    
     @objc var textColor: String = "" {
         didSet {
             let color = hexStringToUIColor(hex: textColor);
@@ -64,37 +64,37 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
         }
     }
 
-
+    
     @objc var placeholderColor: String = "" {
         didSet {
             attributeLabel.placeholderStyle.color = hexStringToUIColor(hex: placeholderColor)
         }
     }
-
+    
     @objc var bgColor: String = "" {
         didSet {
             attributeLabel.backgroundColor = hexStringToUIColor(hex: bgColor)
         }
     }
-
+    
     @objc var borderColor: String = "" {
         didSet {
             attributeLabel.borderColor = hexStringToUIColor(hex: borderColor)
         }
     }
-
+    
     @objc var placeholder: String = "" {
         didSet {
             attributeLabel.placeholder = placeholder;
         }
     }
-
+    
     @objc var contentPath: String = "" {
         didSet {
             attributeLabel.contentPath = contentPath;
         }
     }
-
+    
     @objc var fontFamily: String = "" {
         didSet {
             let font = UIFont.init(name: fontFamily, size: fontSize);
@@ -102,78 +102,78 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
             attributeLabel.placeholderStyle.font = font;
         }
     }
-
+    
     @objc var fontSize: CGFloat = 16 {
         didSet {
             var font: UIFont?;
-
+            
             if (fontFamily == "") {
                 font = UIFont.systemFont(ofSize: fontSize);
             } else {
                 font = UIFont.init(name: fontFamily, size: fontSize);
             }
-
+            
             attributeLabel.font = font;
             attributeLabel.placeholderStyle.font = font;
         }
     }
-
+    
     @objc var characterSpacing: CGFloat = 0.83 {
         didSet {
             attributeLabel.characterSpacing = characterSpacing;
         }
     }
-
+    
     @objc var borderRadius: CGFloat = 0 {
         didSet {
             attributeLabel.layer.cornerRadius = borderRadius;
         }
     }
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         createVgsShow();
     }
-
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
+    
     private func createVgsShow() {
         let stackView = UIStackView.init(arrangedSubviews: [attributeLabel])
         stackView.axis = .vertical
-
+        
         stackView.distribution = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(stackView)
-
+        
         NSLayoutConstraint.activate([
             stackView.leftAnchor.constraint(equalTo: self.leftAnchor),
             stackView.rightAnchor.constraint(equalTo: self.rightAnchor),
             stackView.topAnchor.constraint(equalTo: self.topAnchor),
             stackView.heightAnchor.constraint(equalTo: self.heightAnchor)
         ])
-
+        
         attributeLabel.delegate = self
     }
-
+    
     @objc func revealData(path: String, method: String, payload: VGSJSONData,
                           resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
         if (vgsShow == nil) {
             return;
         }
-
+        
         print("vgsshow revealData, path: \(path), method= \(method), payload = \(payload)")
-
+        
         vgsShow!.request(path: path,
                          method: method == "post" ? .post : .get,
                          payload: method == "post" ? payload : nil) { (requestResult) in
-
+            
             switch requestResult {
             case .success(let code):
                 print("vgsshow success, code: \(code)")
-
+                
                 resolve(code);
             case .failure(let code, let error):
                 print("vgsshow failed, code: \(code), error: \(error)")
@@ -181,25 +181,25 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
             }
         }
     }
-
+    
     func hexStringToUIColor (hex:String) -> UIColor {
         var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-
+        
         if (cString.hasPrefix("#")) {
             cString.remove(at: cString.startIndex)
         }
-
+        
         if (cString.hasPrefix("TRANSPARENT")) {
             return UIColor.clear;
         }
-
+        
         if ((cString.count) != 6) {
             return UIColor.gray
         }
-
+        
         var rgbValue:UInt64 = 0
         Scanner(string: cString).scanHexInt64(&rgbValue)
-
+        
         return UIColor(
             red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
             green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,

--- a/ios/VgsShowReactNativeViewManager.swift
+++ b/ios/VgsShowReactNativeViewManager.swift
@@ -3,11 +3,11 @@ import VGSShowSDK
 
 @objc(VgsShowReactNativeViewManager)
 class VgsShowReactNativeViewManager: RCTViewManager {
-    
+
     override func view() -> (VgsShowReactNativeView) {
         return VgsShowReactNativeView()
     }
-    
+
     @objc(revealData:path:method:payload:resolver:rejecter:) func revealData(_ node: NSNumber, path: String, method: String, payload: VGSJSONData, resolver resolve: @escaping RCTPromiseResolveBlock,
                                                                              rejecter reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
@@ -22,13 +22,13 @@ class VgsShowReactNativeViewManager: RCTViewManager {
 class VgsShowReactNativeView : UIView, VGSLabelDelegate {
     var vgsShow: VGSShow?;
     let attributeLabel = VGSLabel()
-    
+
     @objc var initParams: NSDictionary = NSDictionary() {
         didSet {
             let vaultId = initParams["vaultId"] as! String;
             let environment = initParams["environment"] as! String;
             let customHeaders = initParams.object(forKey: "customHeaders") != nil ? initParams["customHeaders"] as! Dictionary<String, String> : [:];
-            
+
             if (vaultId != nil && environment != nil) {
                 if (environment == "live") {
                     vgsShow = VGSShow(id: vaultId, environment: .live);
@@ -37,14 +37,25 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
                     vgsShow = VGSShow(id: vaultId, environment: .sandbox);
                     vgsShow!.subscribe(attributeLabel)
                 }
-                
+
                 if (vgsShow != nil) {
                     vgsShow?.customHeaders = customHeaders;
                 }
             }
         }
     }
-    
+
+    @objc var format: NSDictionary = NSDictionary() {
+        didSet {
+            if let pattern = format["pattern"] as? String {
+                if let template = format["template"] as? String{
+                    let regex = try! NSRegularExpression(pattern: pattern, options: [])
+                    attributeLabel.addTransformationRegex(regex, template: template)
+                }
+            }
+        }
+    }
+
     @objc var textColor: String = "" {
         didSet {
             let color = hexStringToUIColor(hex: textColor);
@@ -53,37 +64,37 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
         }
     }
 
-    
+
     @objc var placeholderColor: String = "" {
         didSet {
             attributeLabel.placeholderStyle.color = hexStringToUIColor(hex: placeholderColor)
         }
     }
-    
+
     @objc var bgColor: String = "" {
         didSet {
             attributeLabel.backgroundColor = hexStringToUIColor(hex: bgColor)
         }
     }
-    
+
     @objc var borderColor: String = "" {
         didSet {
             attributeLabel.borderColor = hexStringToUIColor(hex: borderColor)
         }
     }
-    
+
     @objc var placeholder: String = "" {
         didSet {
             attributeLabel.placeholder = placeholder;
         }
     }
-    
+
     @objc var contentPath: String = "" {
         didSet {
             attributeLabel.contentPath = contentPath;
         }
     }
-    
+
     @objc var fontFamily: String = "" {
         didSet {
             let font = UIFont.init(name: fontFamily, size: fontSize);
@@ -91,78 +102,78 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
             attributeLabel.placeholderStyle.font = font;
         }
     }
-    
+
     @objc var fontSize: CGFloat = 16 {
         didSet {
             var font: UIFont?;
-            
+
             if (fontFamily == "") {
                 font = UIFont.systemFont(ofSize: fontSize);
             } else {
                 font = UIFont.init(name: fontFamily, size: fontSize);
             }
-            
+
             attributeLabel.font = font;
             attributeLabel.placeholderStyle.font = font;
         }
     }
-    
+
     @objc var characterSpacing: CGFloat = 0.83 {
         didSet {
             attributeLabel.characterSpacing = characterSpacing;
         }
     }
-    
+
     @objc var borderRadius: CGFloat = 0 {
         didSet {
             attributeLabel.layer.cornerRadius = borderRadius;
         }
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         createVgsShow();
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     private func createVgsShow() {
         let stackView = UIStackView.init(arrangedSubviews: [attributeLabel])
         stackView.axis = .vertical
-        
+
         stackView.distribution = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(stackView)
-        
+
         NSLayoutConstraint.activate([
             stackView.leftAnchor.constraint(equalTo: self.leftAnchor),
             stackView.rightAnchor.constraint(equalTo: self.rightAnchor),
             stackView.topAnchor.constraint(equalTo: self.topAnchor),
             stackView.heightAnchor.constraint(equalTo: self.heightAnchor)
         ])
-        
+
         attributeLabel.delegate = self
     }
-    
+
     @objc func revealData(path: String, method: String, payload: VGSJSONData,
                           resolve: @escaping RCTPromiseResolveBlock,
                           reject: @escaping RCTPromiseRejectBlock) {
         if (vgsShow == nil) {
             return;
         }
-        
+
         print("vgsshow revealData, path: \(path), method= \(method), payload = \(payload)")
-        
+
         vgsShow!.request(path: path,
                          method: method == "post" ? .post : .get,
                          payload: method == "post" ? payload : nil) { (requestResult) in
-            
+
             switch requestResult {
             case .success(let code):
                 print("vgsshow success, code: \(code)")
-                
+
                 resolve(code);
             case .failure(let code, let error):
                 print("vgsshow failed, code: \(code), error: \(error)")
@@ -170,25 +181,25 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
             }
         }
     }
-    
+
     func hexStringToUIColor (hex:String) -> UIColor {
         var cString:String = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-        
+
         if (cString.hasPrefix("#")) {
             cString.remove(at: cString.startIndex)
         }
-        
+
         if (cString.hasPrefix("TRANSPARENT")) {
             return UIColor.clear;
         }
-        
+
         if ((cString.count) != 6) {
             return UIColor.gray
         }
-        
+
         var rgbValue:UInt64 = 0
         Scanner(string: cString).scanHexInt64(&rgbValue)
-        
+
         return UIColor(
             red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
             green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,10 @@ export type VgsShowReactNativeProps = {
     environment: 'live' | 'sandbox';
     customHeaders?: Record<string, any>;
   };
+  format?: {
+    pattern: string;
+    template: string;
+  };
 };
 
 const NATIVE_COMP_IDENTIFIER = 'VgsShowReactNativeView';


### PR DESCRIPTION
This will add the capability to format revealed data according to VGS Show [Android](https://www.verygoodsecurity.com/docs/vgs-show/android-sdk/text-view/#data-formatting) and [IOS](verygoodsecurity.com/docs/vgs-show/ios-sdk/samples/#text-formatting-in-vgs-label) documentation.

## Example of usage

```tsx
import VgsShowAttribute from 'vgs-show-react-native';
// ...
const vgsShow = React.useRef<VgsShowAttribute> = null;
<VgsShowAttribute
  ref={vgsShow}
  initParams={{
    environment: ENV,
    vaultId: VAULT_ID,
    // optional, if needed for the upstream service
    customHeaders: {
      Authorization: 'Bearer ' + customerToken,
    },
  }}
  format={{
    pattern:"(\\d{4})(\\d{4})(\\d{4})(\\d{4})"
    template:"$1 $2 $3 $4"
  }}
  contentPath="data.attributes.pan"
  placeholder="Value will appear here"
  style={styles.box}
/>;
// To trigger reveal:
<Button onPress={vgsShow.current?.reveal(PATH, METHOD, CUSTOM_PAYLOAD)}>
```