### PR TITLE
feat: add copy to clipboard

### DIFF
--- a/android/src/main/java/com/vgsshowreactnative/VgsAttrInstance.kt
+++ b/android/src/main/java/com/vgsshowreactnative/VgsAttrInstance.kt
@@ -93,4 +93,8 @@ class VgsAttrInstance(context: ReactContext) : LinearLayout(context) {
 
     this.vgsShow.requestAsync(request.build());
   }
+
+  fun copyToClipboard() {
+    vgsText.copyToClipboard()
+  }
 }

--- a/android/src/main/java/com/vgsshowreactnative/VgsShowReactNativeViewManager.kt
+++ b/android/src/main/java/com/vgsshowreactnative/VgsShowReactNativeViewManager.kt
@@ -40,6 +40,7 @@ class VgsShowReactNativeViewManager : SimpleViewManager<View>() {
         args.getString(2) as String,
         args.getMap(3) as ReadableMap
       )
+      "copyToClipboard" -> (view as VgsAttrInstance).copyToClipboard()
     }
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -305,7 +305,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - vgs-show-react-native (0.1.0):
+  - vgs-show-react-native (0.1.2):
     - React-Core
     - VGSShowSDK
   - VGSShowSDK (1.0.4):
@@ -474,11 +474,11 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  vgs-show-react-native: 6a2bc9ccc1acc7411f1a8a8e3034b839e22fb21e
+  vgs-show-react-native: feaef73c7c6561b2e4a2dff2cc7b22174422ea19
   VGSShowSDK: 82d8c1c1d1e3cf32c81b26057f7e7aaa20f91cfc
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 22d1aef0643c7abb6f0d30de17ef3ea0b598764c
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/ios/VgsShowReactNativeViewManager.m
+++ b/ios/VgsShowReactNativeViewManager.m
@@ -21,4 +21,6 @@ RCT_EXTERN_METHOD(revealData:(nonnull NSNumber *)node path:(nonnull NSString *)p
           resolver:(RCTPromiseResolveBlock)resolve
           rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(copyToClipboard:(nonnull NSNumber *)node)
+
 @end

--- a/ios/VgsShowReactNativeViewManager.swift
+++ b/ios/VgsShowReactNativeViewManager.swift
@@ -17,6 +17,15 @@ class VgsShowReactNativeViewManager: RCTViewManager {
             component.revealData(path: path, method: method, payload: payload, resolve: resolve, reject: reject)
         }
     }
+
+    @objc(copyToClipboard) func copyToClipboard(_ node: NSNumber) {
+        DispatchQueue.main.async {
+            let component = self.bridge.uiManager.view(
+                forReactTag: node
+            ) as! VgsShowReactNativeView
+            component.copyToClipboard()
+        }
+    }
 }
 
 class VgsShowReactNativeView : UIView, VGSLabelDelegate {
@@ -169,6 +178,13 @@ class VgsShowReactNativeView : UIView, VGSLabelDelegate {
                 reject("error", error?.localizedDescription, error)
             }
         }
+    }
+
+    @objc func copyToClipboard() {
+        if (attributeLabel == nil) {
+            return;
+        }
+        attributeLabel.copyTextToClipboard(format: .raw)
     }
     
     func hexStringToUIColor (hex:String) -> UIColor {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -100,6 +100,23 @@ export class VgsShowAttribute extends React.Component<VgsShowReactNativeProps> {
     return Promise.reject('No ref available for native comp!');
   }
 
+  copyToClipboard(): void {
+    const handle = findNodeHandle(this._nativeRef);
+    const copy = Platform.select({
+      ios: () => {
+        NativeModules.VgsShowReactNativeViewManager.copyToClipboard(handle);
+      },
+      android: () => {
+        UIManager.dispatchViewManagerCommand(
+          handle,
+          'copyToClipboard' as any,
+          []
+        );
+      },
+    });
+    copy?.();
+  }
+
   render() {
     return (
       <VgsShowAttributeNative


### PR DESCRIPTION
This will add the capability to copy to the clipboard revealed data.

Relates to #1 

# Example


```tsx
import VgsShowAttribute from 'vgs-show-react-native';

// ...

const vgsShow = React.useRef<VgsShowAttribute> = null;

<VgsShowAttribute
  ref={vgsShow}
  initParams={{
    environment: ENV,
    vaultId: VAULT_ID,
    // optional, if needed for the upstream service
    customHeaders: {
      Authorization: 'Bearer ' + customerToken,
    },
  }}
  contentPath="data.attributes.pan"
  placeholder="Value will appear here"
  style={styles.box}
/>;

// To trigger reveal:
<Button onPress={vgsShow.current?.reveal(PATH, METHOD, CUSTOM_PAYLOAD)}>
// To trigger copy after revealed:
<Button onPress={vgsShow.current?.copyToClipboard()} title="Copy">
```